### PR TITLE
Do not place commas in 88 continue'ed text

### DIFF
--- a/lib/bai_parser.rb
+++ b/lib/bai_parser.rb
@@ -49,7 +49,7 @@ module BaiParser
           next_line.chomp!
           count += 1
           if next_line[0..1] == '88'
-            record.sub!(/\/\s*$/,',')
+            record.sub!(/\/\s*$/, '')
             record += next_line[3..-1]
           else
             break


### PR DESCRIPTION
hi,

I was noticing random, unexpected commas in transaction text fields parsed by bai_parser.

ex:
```
WIRE REFERENCE: 15041232233,0000041275XXXXX FOOBAR CORPORA,TION MAIN ACCOUNT 123 SOME ST, 4TH FL, SAN DIEGO CA 95,108 EC1502353021118 ORG=Foobar Funding ...
```

turns out this `sub!` highlighted in the diff was replacing the line delimiter `/` of the continue'ed record (the preious line) by a comma. As far as I can tell this is incorrect, and is introducing a comma that was not in the original text.

I'm using this doc as reference in which i fail to notice such a requirement. https://www.bai.org/libraries/site-general-downloads/cash_management_2005.sflb.ashx

the above line is now produced as I expected it, without the unexpected commas:
```
WIRE REFERENCE: 150412322330000041275XXXXX FOOBAR CORPORATION MAIN ACCOUNT 123 SOME ST, 4TH FL SAN DIEGO CA 95108 EC1502353021118 ORG=Foobar Funding ...
```